### PR TITLE
fix promo overflow

### DIFF
--- a/src/components/Promo/Promo.css
+++ b/src/components/Promo/Promo.css
@@ -1,7 +1,7 @@
 .promo {
   max-width: 1360px;
   margin: 0 auto;
-  overflow: hidden;
+  padding: 0 40px;
 }
 
 .promo-brands {

--- a/src/components/Promo/Promo.css
+++ b/src/components/Promo/Promo.css
@@ -1,6 +1,7 @@
 .promo {
   max-width: 1360px;
   margin: 0 auto;
+  overflow: hidden;
 }
 
 .promo-brands {


### PR DESCRIPTION
Добавила секции promo боковой padding, как у карусели с карточками товаров, чтобы убрать горизонтальный скролл при масштабе страницы 100%
![1](https://github.com/Environmentally-friendly-products-store/meeco-frontend/assets/107261441/3e844819-2ee9-4e68-8106-8f20c19e84c9)
